### PR TITLE
Upgrade Spring Boot and other dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.21.RELEASE</version>
+        <version>2.1.6.RELEASE</version>
     </parent>
 
     <dependencies>
@@ -38,14 +38,14 @@
         <dependency>
         	<groupId>org.springframework.security</groupId>
         	<artifactId>spring-security-core</artifactId>
-        	<version>4.2.12.RELEASE</version>
+        	<version>5.1.5.RELEASE</version>
         </dependency>
 
         <!-- json web token support -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
-            <version>0.6.0</version>
+            <version>0.9.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/trycb/service/TokenService.java
+++ b/src/main/java/trycb/service/TokenService.java
@@ -1,6 +1,5 @@
 package trycb.service;
 
-import com.couchbase.client.deps.io.netty.util.CharsetUtil;
 import com.couchbase.client.java.document.json.JsonObject;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -8,6 +7,8 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Base64Utils;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 @Service
 public class TokenService {
@@ -51,7 +52,7 @@ public class TokenService {
 
     private String verifySimple(String token) {
         try {
-            return new String(Base64Utils.decodeFromString(token));
+            return new String(Base64Utils.decodeFromString(token), UTF_8);
         } catch (Exception e) {
             throw new IllegalStateException("Could not verify simple token", e);
         }
@@ -75,6 +76,6 @@ public class TokenService {
     }
 
     private String buildSimpleToken(String username) {
-        return Base64Utils.encodeToString(username.getBytes(CharsetUtil.UTF_8));
+        return Base64Utils.encodeToString(username.getBytes(UTF_8));
     }
 }

--- a/src/main/java/trycb/util/StartupPreparations.java
+++ b/src/main/java/trycb/util/StartupPreparations.java
@@ -82,7 +82,7 @@ public class StartupPreparations implements InitializingBean {
         for (N1qlQueryRow indexRow : indexResult) {
             String name = indexRow.value().getString("name");
             Boolean isPrimary = indexRow.value().getBoolean("is_primary");
-            if (name.equals(PRIMARY_NAME) || isPrimary == Boolean.TRUE) {
+            if (name.equals(PRIMARY_NAME) || Boolean.TRUE.equals(isPrimary)) {
                 hasPrimary = true;
             } else {
                 foundIndexes.add(name);


### PR DESCRIPTION
Motivation
==========

Couchbase SDK 3.0 requires Spring boot 2.x. Also, there was a GitHub
security vulnerability warning for the old version of
spring-security-core.

Modifications
=============

Bump dependency versions.

Now that the project uses Java 1.8, we can use StandardCharsets.UTF_8
instead of the version from Netty's CharsetUtils.

Fix a couple of issues detected by FindBugs.