### PR TITLE
Fix issue with docker-compose volume and jar not found error

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,6 @@ Install the dependencies:
 
     mvn clean install
 
-Note that `spring-boot-devtools` is installed as a dependency, so you can run the server with
-the benefit of automatic restarting as you make changes.
-
 The first time you run against a new database image, you may want to use the provided
 `wait-for-couchbase.sh` wrapper to ensure that all indexes are created.
 For example, using the Docker image provided:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       - db
     ports:
       - 8080:8080
-    volumes:
-      - .:/app
     container_name: try-cb-api
   
   frontend:

--- a/mix-and-match.yml
+++ b/mix-and-match.yml
@@ -10,8 +10,6 @@ services:
       - CB_USER
       - CB_PSWD
     command: --storage.host=${CB_HOST} --storage.username=${CB_USER} --storage.password=${CB_PSWD}
-    volumes:
-      - .:/app
     container_name: try-cb-api-mm
 
   frontend:

--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,6 @@
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>1.5.9</version>
         </dependency>
-
-        <!-- spring-boot dev tools to enable hot-reloading -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 
     <!-- for couchbase prereleases, use the couchbase repo -->


### PR DESCRIPTION
This was causing a similar issue to what the Scala app was facing with `unable to access jar file` when using `docker-compose up`.

Because we generate the jar during the Docker image build time, when we execute `docker-compose up` we're mounting a volume with all the project files from the **host** machine, which seems to override whatever was previously built in the image.  This is why there was an error of `unable to access jar file` when the container attempts to start.

To avoid complications I am removing the volume and the hot reload library as it is not worth the trouble.